### PR TITLE
Fixes: fasd: 32: cd: can't cd to begin_path

### DIFF
--- a/fasd
+++ b/fasd
@@ -29,7 +29,7 @@
 
 get_vcs() {
     local begin_path=$1
-    cd begin_path
+    cd "$begin_path"
     while [ "$PWD" != "/" ]; do
         if { [ -d .git ] || [ -d .hg ] ;} then
             echo $PWD


### PR DESCRIPTION
This error was printed every time I used z.
Unfortunately I have not been able to reproduce it in docker.
This does fix the issue though, and the code seems like it has an oversight.

The error is not captured by `_FASD_SINK`.
Example:

```
➜ export _FASD_SINK=/tmp/fasd.error
➜ z dotfiles
/home/matthew/.local/bin/fasd: 32: cd: can't cd to begin_path
➜ cat /tmp/fasd.error
➜ ls -lh /tmp/fasd.error
-rw-r--r-- 1 matthew matthew 0 Oct 19 21:18 /tmp/fasd.error
```