### PR TITLE
Add fasd_cd to the _FASD_IGNORE envvar

### DIFF
--- a/fasd
+++ b/fasd
@@ -79,7 +79,7 @@ fasd() {
           fi
           [ -z "$_FASD_BLACKLIST" ] && _FASD_BLACKLIST="--help"
           [ -z "$_FASD_SHIFT" ] && _FASD_SHIFT="sudo busybox"
-          [ -z "$_FASD_IGNORE" ] && _FASD_IGNORE="fasd ls echo"
+          [ -z "$_FASD_IGNORE" ] && _FASD_IGNORE="fasd fasd_cd ls echo"
           [ -z "$_FASD_SINK" ] && _FASD_SINK=/dev/null
           [ -z "$_FASD_TRACK_PWD" ] && _FASD_TRACK_PWD=1
           [ -z "$_FASD_MAX" ] && _FASD_MAX=2000


### PR DESCRIPTION
Fixes #24 

## Root Cause (by Claude Code)
The `--proc` hook processes every command typed by the user and calls `fasd --add` on valid-path arguments. `fasd_cd` is NOT in the default `_FASD_IGNORE="fasd ls echo"`, so when the user runs `fasd_cd -D /path`, the hook calls `fasd --add /path` (since `/path` is a real directory on disk).

- **Bash** (PROMPT_COMMAND, fires *after* the command): hook re-adds the path *after* the delete → delete is undone. This is a definitive regression.
- **Zsh** (preexec, fires *before* the command): hook adds before delete, so delete should win in theory. However prezto's fasd module may use a different hook order, or there may be an edge-case in the temp-file swap if both operations hit the file nearly simultaneously.

In all cases, `fasd_cd` behaving as a trackable command is wrong — it is a fasd management wrapper, not a directory navigation command, and its path arguments are fasd flags/query terms, not directories to record.

## Testing
```
 ~ ❯❯❯ fasd_cd -i go
2       6          /home/tag/go
1       36.584     /home/tag/Code/bagoup
> ^C%
 ~ ❯❯❯ fasd_cd -D /home/tag/go

 ~ ❯❯❯ fasd_cd -i go
 ~/C/bagoup ❯❯❯
```