### PR TITLE
Add a make check target; remove nonexistent GH action steps

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -2,7 +2,6 @@ name: Makefile CI
 
 on:
   push:
-    branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
 
@@ -14,14 +13,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: configure
-      run: ./configure
-
     - name: Install dependencies
-      run: make
+      run: sudo make install
 
     - name: Run check
       run: make check
-
-    - name: Run distcheck
-      run: make distcheck

--- a/Makefile
+++ b/Makefile
@@ -13,4 +13,7 @@ install:
 	${INSTALLDIR} ${DESTDIR}${BINDIR}
 	${INSTALLBIN} fasd ${DESTDIR}${BINDIR}
 
-.PHONY: all install uninstall
+check:
+	fasd --help
+
+.PHONY: all install uninstall check


### PR DESCRIPTION
- There is no configure file.
- The `make all` default target when you run `make` doesn't do anything.
- Add a basic `make check` target.
- There is no `make distcheck` target.
- Run makefile action for pushes to all branches.